### PR TITLE
Version 0.1.1-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ____    __    ____  ___       __       __       _______  __        ______   ____
     \__/  \__/ /__/     \__\ |_______||_______||__|     |_______| \______/      \__/  \__/     
 ```
 
-**Wallflow** is a bash script to set wallpapers from **Wallhaven** API in most **Popular** Linux Desktop Enviroments. Works with X11.
+**Wallflow** is a bash script to set wallpapers from **Wallhaven** API in most **Popular** Linux Desktop Environments. Works with X11.
 
 **IMPORTANT:** I wrote this script for myself, even if I tried to make this compatible with others devices I can´t guarantee that works on every machine. If you found a problem or know how to solve it. Create a new issue.
 

--- a/src/wallflow.sh
+++ b/src/wallflow.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export CONFIG_FILE_PATH="$HOME/.config/wallflow/config.json"
-export WALLFLOW_VERSION="0.1.0"
+export WALLFLOW_VERSION="0.1.1"
 export OUTPUT_JSON_FILE_PATH="/tmp/wallflow_response.json"
 
 # Monitor name

--- a/src/wallflow.sh
+++ b/src/wallflow.sh
@@ -134,6 +134,7 @@ update_wallpaper() {
                 ;;
             gnome)
                 gsettings set org.gnome.desktop.background picture-uri "file://$image_path"
+                gsettings set org.gnome.desktop.background picture-uri-dark "file://$image_path"
                 echo "Wallpaper updated for GNOME"
                 ;;
             cinnamon)


### PR DESCRIPTION
- Fixed the issue with GNOME not changing the background for the dark theme
- Fixed the typo in 'Environments' on the help screen